### PR TITLE
Adding .pcap extension.

### DIFF
--- a/daemonlogger.c
+++ b/daemonlogger.c
@@ -1415,7 +1415,7 @@ int main(int argc, char *argv[])
 
     rt_config.rollsize = 2 * (GIGABYTE);
 
-    rt_config.logfilename = strdup("daemonlogger.pcap");
+    rt_config.logfilename = strdup("daemonlogger");
 
     parse_cmd_line(argc, argv);
 

--- a/daemonlogger.c
+++ b/daemonlogger.c
@@ -432,7 +432,7 @@ char *get_filename()
     {
         if(snprintf(rt_config.logdir, 
                     STDBUF, 
-                    "%s/%s.%lu", 
+                    "%s/%s.%lu.pcap", 
                     rt_config.logpath, 
                     rt_config.logfilename, 
                     (long unsigned int) currtime) < 0)
@@ -442,7 +442,7 @@ char *get_filename()
     {
         if(snprintf(rt_config.logdir, 
                     STDBUF, 
-                    "%s.%lu",
+                    "%s.%lu.pcap",
                     rt_config.logfilename,
                     (long unsigned int) currtime) < 0)
             return NULL;        


### PR DESCRIPTION
Howdy, I created this PR to add the .pcap extension to the pcap files being created. I made this modification since an automated processor I use only recognizes files with that extension and it makes sense to me to have the files use that convention rather than just the identifier currently being used. 

No sweat if you don't think it's a good idea; I created the PR more as a suggestion than anything else. If you think it would better as an added parameter to the application, I can also do that.

Thanks!